### PR TITLE
retract versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/delphix/dct-sdk-go
 go 1.17
 
 retract (
+	v1.1.0 // Published for testing
 	v1.0.0-b1 // Published for testing
-	v0.22.321 // Published for testing
 )
 
 require golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/delphix/dct-sdk-go
 
 go 1.17
 
+retract (
+	v1.0.0-b1 // Published for testing
+	v0.22.321 // Published for testing
+)
+
 require golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
 
 require (


### PR DESCRIPTION
Retracting following: 
v1.0.0-b1 
v1.1.0 

Once the PR gets merged, we need to tag a new version. If needed, that new version can also be retracted to fall back on previous version. More info here: https://go.dev/ref/mod#go-mod-file-retract