### PR TITLE
retract versions fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 retract (
 	v1.1.0 // Published for testing
 	v1.0.0-b1 // Published for testing
+	v1.1.1 // Contains retractions only.
 )
 
 require golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a


### PR DESCRIPTION
retract version fix : 

To retract a version, a module author should add a retract directive to go.mod, then publish a new version containing that directive. The new version must be higher than other release or pre-release versions; that is, the @latest [version query](https://go.dev/ref/mod#version-queries) should resolve to the new version before retractions are considered. The go command loads and applies retractions from the version shown by go list -m -retracted $modpath@latest (where $modpath is the module path).

**A version containing retractions may retract itself. If the highest release or pre-release version of a module retracts itself, the @latest query resolves to a lower version after retracted versions are excluded.**

More: https://go.dev/ref/mod#go-mod-file-retract